### PR TITLE
Team tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ And then can be run with something like:
 ```bash
 docker run -v ~/.kube/config:/root/.kube/config newrelic-sync sync --kubernetes-config=/root/.kube/config --new-relic-api-key=XXXXXXXXXXXXXX --dry-run namespace
 ```
+
+Use the UA_TEAM_NAME environment variable to control team tag applied to synthetics rules. Default: sapp

--- a/cmd/openshift-newrelic-synthetics/sync/command.go
+++ b/cmd/openshift-newrelic-synthetics/sync/command.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"net/url"
+	"os"
 
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
@@ -29,6 +30,8 @@ func syncSynthetics(client *newrelic.NewRelic, routes []routev1.Route, location 
 	if err != nil {
 		return err
 	}
+
+	team := getTeamName()
 
 	tags := make(map[string][]entities.Tag, len(routes))
 
@@ -105,6 +108,10 @@ func syncSynthetics(client *newrelic.NewRelic, routes []routev1.Route, location 
 				Key:    entityutils.TagOpenShiftRouteToName,
 				Values: []string{route.Spec.To.Name},
 			},
+			{
+				Key:    entityutils.TagTeamTagName,
+				Values: []string{team},
+			},
 		}
 	}
 
@@ -129,6 +136,14 @@ func syncSynthetics(client *newrelic.NewRelic, routes []routev1.Route, location 
 	}
 
 	return nil
+}
+
+func getTeamName() string {
+	team := os.Getenv("UA_TEAM_NAME")
+	if len(team) == 0 {
+		return entityutils.TagTeamName
+	}
+	return team
 }
 
 func (cmd *command) run(c *kingpin.ParseContext) error {

--- a/internal/newrelic/entity/const.go
+++ b/internal/newrelic/entity/const.go
@@ -9,9 +9,9 @@ const (
 	TagOpenShiftRouteToKind = "openshiftRouteToKind"
 	// TagOpenShiftRouteToName is used to identify the OpenShift Route "To" Name.
 	TagOpenShiftRouteToName = "openshiftRouteToName"
-	// UA team tag name
+	// UA team tag name.
 	TagTeamTagName = "team"
-	// UA default team name
+	// UA default team name.
 	TagTeamName = "sapp"
 
 	// TypeMonitor is used to search for monitors.

--- a/internal/newrelic/entity/const.go
+++ b/internal/newrelic/entity/const.go
@@ -9,6 +9,10 @@ const (
 	TagOpenShiftRouteToKind = "openshiftRouteToKind"
 	// TagOpenShiftRouteToName is used to identify the OpenShift Route "To" Name.
 	TagOpenShiftRouteToName = "openshiftRouteToName"
+	// UA team tag name
+	TagTeamTagName = "team"
+	// UA default team name
+	TagTeamName = "sapp"
 
 	// TypeMonitor is used to search for monitors.
 	TypeMonitor = "MONITOR"


### PR DESCRIPTION
Adds `team:sapp` to tags in New Relic synthetics created by this sync process.

Defaults to sapp, but can be changed via UA_TEAM_NAME env var.