### PR TITLE
Adds a trailing slash for non-root paths to avoid redirects.

### DIFF
--- a/cmd/openshift-newrelic-synthetics/sync/command.go
+++ b/cmd/openshift-newrelic-synthetics/sync/command.go
@@ -46,6 +46,11 @@ func syncSynthetics(client *newrelic.NewRelic, routes []routev1.Route, location 
 			uri.Scheme = "https" // @todo, Find a cost.
 		}
 
+		// Add trailing slash to avoid redirects on non-root paths.
+		if uri.Path != "/" {
+			uri.Path = uri.Path + "/"
+		}
+
 		urlString := uri.String()
 
 		logger := log.WithFields(log.Fields{


### PR DESCRIPTION
Monitoring should avoid redirects
https://www.adelaide.edu.au/pace 301 redirects to https://www.adelaide.edu.au/pace/